### PR TITLE
Syntaxe PHP < 7.4

### DIFF
--- a/src/MintoD/PlayerBar/Bar.php
+++ b/src/MintoD/PlayerBar/Bar.php
@@ -8,8 +8,8 @@ use pocketmine\plugin\PluginBase;
 use MintoD\PlayerBar\Main;
 
 class Bar extends Task {
-    public int $currentTick = 10;
-    private Main $plugin;
+    public $currentTick = 10;
+    private $plugin;
     private $player;
 
     public function __construct(Main $plugin, $player)


### PR DESCRIPTION
I propose these two small changes because otherwise your plugins would work only with versions of PHP above 7.4 and not below.